### PR TITLE
Only apply extra classes when present.

### DIFF
--- a/src/MalibuIcon.js
+++ b/src/MalibuIcon.js
@@ -29,8 +29,15 @@ export default class MalibuIcon extends React.Component {
         height: `${size}px`,
       }
     }
+
+    let classNames = `malibu-fill-gradient-${fillClass}`
+
+    if (extraClasses) {
+      classNames += ` ${extraClasses}`
+    }
+
     return (
-      <svg style={style} className={`malibu-fill-gradient-${fillClass} ${extraClasses}`}><use xlinkHref={`#${name}`}></use></svg>
+      <svg style={style} className={classNames}><use xlinkHref={`#${name}`}></use></svg>
     )
   }
 }

--- a/tests/MalibuIcon_test.js
+++ b/tests/MalibuIcon_test.js
@@ -13,6 +13,7 @@ describe('MalibuIcon', () => {
     const wrapper = shallow(<MalibuIcon name='foo' />)
     expect(wrapper).to.not.have.prop('style')
     expect(wrapper).to.have.className('malibu-fill-gradient-purple')
+    expect(wrapper).not.to.have.className('undefined')
     expect(wrapper.find('use')).to.be.present()
     expect(wrapper.find('use')).to.have.prop('xlinkHref').equal('#foo')
   })


### PR DESCRIPTION
Otherwise we end up with `undefined`.