### PR TITLE
Added support for different Malibu icon sets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,12 @@ This package offers two components: `<MalibuSprites>` and `<MalibuIcon>`.
 
 Put this component on your page only once, it fetches and displays the entire spritesheet.
 
+By default this will load the product sprites. To load the marketing sprites, add the `set` property.
+
+```js
+<MalibuSprites set='marketing'/>
+```
+
 #### `<MalibuIcon>`
 
 Use this component to instantiate an icon.

--- a/src/MalibuSprites.js
+++ b/src/MalibuSprites.js
@@ -10,7 +10,7 @@ const alternativeSpriteSets = [
 export default class MalibuSprites extends React.Component {
   static propTypes = {
     handleUpdate: PropTypes.func,
-    version: PropTypes.string.isRequired, 
+    version: PropTypes.string.isRequired,
     set: PropTypes.oneOf(alternativeSpriteSets)
   }
 

--- a/src/MalibuSprites.js
+++ b/src/MalibuSprites.js
@@ -3,15 +3,20 @@ import PropTypes from 'prop-types'
 import SVGInline from 'react-svg-inline'
 import 'whatwg-fetch'
 
+const alternativeSpriteSets = [
+  'marketing'
+]
+
 export default class MalibuSprites extends React.Component {
   static propTypes = {
     handleUpdate: PropTypes.func,
-    version: PropTypes.string.isRequired,
+    version: PropTypes.string.isRequired, 
+    set: PropTypes.oneOf(alternativeSpriteSets)
   }
 
   static defaultProps = {
     handleUpdate: () => {},
-    version: 'latest',
+    version: 'latest'
   }
 
   state = {
@@ -28,8 +33,10 @@ export default class MalibuSprites extends React.Component {
   }
 
   fetchSprites = () => {
-    const { version } = this.props
-    fetch(`https://www.herokucdn.com/malibu/${version}/sprite.svg`)
+    const { version, set } = this.props
+    const file = set ? `${set}/sprite.svg` : 'sprite.svg'
+
+    fetch(`https://www.herokucdn.com/malibu/${version}/${file}`)
       .then((res) => (res.text()))
       .then((sprites) => {
         this.setState({

--- a/tests/MalibuSprites_test.js
+++ b/tests/MalibuSprites_test.js
@@ -26,10 +26,22 @@ describe('MalibuSprite', () => {
     expect(fetchMock.lastUrl()).to.equal(url)
   })
 
+  it('fetches different sprites when set is provided', () => {
+    const set = 'marketing'
+    const url = `https://www.herokucdn.com/malibu/latest/${set}/sprite.svg`
+    fetchMock.get(url, sprites)
+    mount(<MalibuSprites set={set} />)
+    expect(fetchMock.lastUrl()).to.equal(url)
+  })
+
   it('correctly sets the content of sprites when fetched', () => {
     const wrapper = shallow(<MalibuSprites />)
     wrapper.setState({sprites})
     wrapper.update()
     expect(wrapper.props().svg).to.equal(sprites)
+  })
+
+  it('does not permit arbitrary set values', () => {
+    expect(() => (shallow(<MalibuSprites name='foo' set='WRONG'/>))).to.throw()
   })
 })


### PR DESCRIPTION
Hey @idan, this is awesome!

We've added support for marketing icons in Malibu, so here's a PR to add support for it to react-malibu.

To load different icon sets, I added a `set` prop to `<MalibuSprites />`:
```<MalibuSprites set='marketing' />```

Happy to discuss other options for implementation, too.