### PR TITLE
dont set state after component unmounting

### DIFF
--- a/src/MalibuSprites.js
+++ b/src/MalibuSprites.js
@@ -48,10 +48,12 @@ export default class MalibuSprites extends React.Component {
     fetch(`https://www.herokucdn.com/malibu/${version}/${file}`)
       .then((res) => (res.text()))
       .then((sprites) => {
-        if (this._isMounted) this.setState({
-          fetchTries: 0,
-          sprites,
-        })
+        if (this._isMounted) {
+          this.setState({
+            fetchTries: 0,
+            sprites,
+          })
+      }
       })
       .catch((err) => {
         if (!this._isMounted) return
@@ -70,4 +72,3 @@ export default class MalibuSprites extends React.Component {
     return (<SVGInline svg={sprites}/>)
   }
 }
-

--- a/src/MalibuSprites.js
+++ b/src/MalibuSprites.js
@@ -21,13 +21,20 @@ export default class MalibuSprites extends React.Component {
     version: 'latest'
   }
 
+  _isMounted = false
+
   state = {
     fetchTries: 0,
     sprites: '',
   }
 
   componentDidMount () {
+    this._isMounted = true
     this.fetchSprites()
+  }
+
+  componentWillUnmount () {
+    this._isMounted = false
   }
 
   componentDidUpdate () {
@@ -41,16 +48,17 @@ export default class MalibuSprites extends React.Component {
     fetch(`https://www.herokucdn.com/malibu/${version}/${file}`)
       .then((res) => (res.text()))
       .then((sprites) => {
-        this.setState({
+        if (this._isMounted) this.setState({
           fetchTries: 0,
           sprites,
         })
       })
       .catch((err) => {
+        if (!this._isMounted) return
         // Retry with exponential backoff
         let { fetchTries } = this.state
         fetchTries += 1
-        this.setState({fetchTries})
+        this.setState({ fetchTries })
         const fetchDelaySeconds = 2 ** fetchTries
         console.warn(`Error when fetching Malibu sprites, retrying in ${2 ** fetchTries}`, err)
         setTimeout(this.fetchSprites, fetchDelaySeconds ** 1000)
@@ -62,3 +70,4 @@ export default class MalibuSprites extends React.Component {
     return (<SVGInline svg={sprites}/>)
   }
 }
+

--- a/src/MalibuSprites.js
+++ b/src/MalibuSprites.js
@@ -53,7 +53,7 @@ export default class MalibuSprites extends React.Component {
             fetchTries: 0,
             sprites,
           })
-      }
+        }
       })
       .catch((err) => {
         if (!this._isMounted) return


### PR DESCRIPTION
Wanted to use https://developer.mozilla.org/en-US/docs/Web/API/AbortController#Browser_compatibility, but it is not supported in IE.

Using old way of avoiding setting state after component unmount:
https://codesandbox.io/s/nwwrrpvqw4?file=/src/axios-track-mounted.js

(verified demo and tests still function properly)