### PR TITLE
Remove np package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "clean": "nwb clean-module && npm clean-demo",
     "start": "nwb serve-react-demo",
     "test": "yarn run lint && yarn run mocha -- --require jsdom-global/register --require babel-register tests/*_test.js",
-    "lint": "yarn run eslint .",
-    "release": "np"
+    "lint": "yarn run eslint ."
   },
   "dependencies": {
     "babel-polyfill": "^6.23.0",


### PR DESCRIPTION
So after looking into the `np` package regarding the unexpected push to master it did from the previous release, it is not exactly clear how that issue occurred. Also the extendibility of the package seems lackluster with respect to having the scripts draft a release pr and lerna integrations don’t look as feasible. I think from a security standpoint, it’s worth removing the package and finding a better alternative at a later date. Since the current script flow relies on branch or tag options to create npm releases - not even addressing unexpected commits to the master branch, we could actually save ourselves an overly complex release process by just going back to `npm`.