### PR TITLE
Bump picomatch from 2.3.1 to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "eslint-plugin-react/**/minimatch": "^3.1.4",
     "mocha/**/minimatch": "^9.0.7",
     "np/**/minimatch": "^9.0.7",
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": ">=7.0.3",
+    "@babel/cli/**/picomatch": "^2.3.2",
+    "np/**/picomatch": "^2.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5061,10 +5061,10 @@ picocolors@1.1.1, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1, picomatch@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/f9f4ec17-d8db-42f8-bf58-dcda12a12663" width="24" align="top"> **3PP Grackle** (automated dependency triage -- Frontend DX) -- **babysit** _(AT run `8a9f560b`)_

## Summary

Fixes 2 **HIGH** severity 3PP vulnerabilities in `picomatch` (GHSA-c2c7-rcm5-vvqj, GHSA-3v7f-55p6-f55p).

`picomatch` prior to 2.3.2 is vulnerable to two high-severity advisories that were first patched in 2.3.2. The package appears in this repo only via build/test toolchain parents.

**Production risk:** Build-time only
Build-time only: `picomatch` is pulled in transitively by `@babel/cli` and `np`, both of which are `devDependencies`. It is not loaded by the published `react-malibu` library at runtime. See the Risk Classification section below for the canonical copy for each tier.

**Strategy:** override

## Changes

### package.json

Added 2 version-range-specific `resolutions` entries forcing `picomatch` to the patched version under the two parent chains that pull it in:

```json
"@babel/cli/**/picomatch": "^2.3.2",
"np/**/picomatch": "^2.3.2"
```

**Why scoped (parent-selector) resolutions instead of a global `"picomatch": "^2.3.2"`?** `picomatch` appears in the tree twice -- older 2.x under the babel/np toolchain and 4.x elsewhere. A global override would attempt to collapse both versions and risk breaking packages that declare a peer range like `picomatch@^4`. The `<parent>/**/picomatch` selectors isolate the fix to the two vulnerable chains (`@babel/cli` and `np`) without touching the 4.x resolution. Upgrading the direct parents does not re-resolve their locked transitives, so a `resolutions` override is the minimal-risk way to force the lockfile to pick up the patched 2.3.2 line.

### yarn.lock

Lockfile re-resolved so `picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1, picomatch@^2.3.2` now points at `2.3.2` (previously `2.3.1`). No other packages changed.

## Risk Classification

| Classification | When to use | PR copy |
|----------------|-------------|---------|
| Runtime | Vulnerable package reaches the production code path (any path from a `dependencies` entry) | "This vulnerability is reachable in production. Priority: HIGH." |
| Build-time | Vulnerable package only appears under `devDependencies` and its parents are build tools (webpack, babel, ember-cli) | "This vulnerability exists only in build-tool dependencies. Production risk: NONE. Remediation prevents scanner noise and supply-chain exposure during CI." |
| Test-only | Vulnerable package only appears under test-framework parents (jest, mocha, vitest, karma) | "This vulnerability exists only in test framework dependencies. Production risk: NONE." |

This PR: **Build-time**. `picomatch` parents are `@babel/cli` (babel build tool) and `np` (release tool), both `devDependencies`.

## Vulnerabilities Fixed

| CVE/GHSA | Package | Severity | Fixed Version |
|----------|---------|----------|---------------|
| GHSA-c2c7-rcm5-vvqj | picomatch | high | ^2.3.2 |
| GHSA-3v7f-55p6-f55p | picomatch | high | ^2.3.2 |

## How to Test

```bash
# Install with the pinned node from engines (20.x or 22.12+)
yarn install

# Lint, build, test -- all must pass
yarn run lint
yarn run build
yarn run test

# Confirm picomatch is at the patched version in the toolchain paths
yarn why picomatch
```

Exercise the affected surface by running the full test suite (the babel/register pipeline and vite build both load `picomatch` transitively via micromatch/anymatch). No application code imports `picomatch` directly, so the smoke path is the build/test pipeline itself.

## Validation

Validation was run on the PR head branch (`babysit/5cc97b07/picomatch`) with node 20.19.6 (satisfies `engines.node=^20.19.0 || >=22.12.0`):

- Install (post-fix): PASS (`yarn install`)
- Lint (post-fix): PASS (exit 0)
- Build (post-fix): PASS (exit 0)
- Tests (post-fix): PASS (exit 0, 10 passing)

Full log: `.logs/babysit-rebody-validate-1777138112.log`.

## Notes

- Dependency chain: `react-malibu -> @babel/cli -> ... -> picomatch@2.3.1` and `react-malibu -> np -> ... -> picomatch@2.3.1`. Both now resolve to `2.3.2` via the scoped `resolutions` entries.
- No source changes; this is a lockfile + `resolutions`-only fix. The patched 2.3.2 is API-compatible with 2.3.1 (patch release).
- The 4.x line of `picomatch` is unaffected by these advisories and is left untouched.

---
<sub>skill-sig: `26cfcbaf` · grackle-sig: `8a9f560b` · 3pp-skill canonical pipeline · 3pp-grackle babysit</sub>

<!-- 3pp-grackle-babysit:v1 run_id=babysit-2026-04-25-17-21-56 short_id=8a9f560b -->
