### PR TITLE
verification: add smoke test suite (no behavior change)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /node_modules
 /umd
 npm-debug.log*
+.logs/

--- a/tests/smoke_test.js
+++ b/tests/smoke_test.js
@@ -1,0 +1,79 @@
+/**
+ * Smoke test -- verifies the public surface of @heroku/react-malibu
+ * builds and renders without error. This is layer L4 of the workspace
+ * verification ladder (see 3pp-grackle/docs/verification-specs/react-malibu.md).
+ *
+ * Asserts:
+ *   1. The built `lib/` directory exists after `yarn build`
+ *   2. The package's public exports (MalibuIcon, MalibuSprites) load
+ *   3. Each component server-renders without throwing
+ *   4. MalibuIcon produces an <svg> tag for a known icon name
+ *
+ * Run via: yarn test (after yarn build) -- this file is picked up by
+ * the existing `mocha tests/*_test.js` glob.
+ */
+
+require('@babel/register')
+
+const path = require('path')
+const fs = require('fs')
+const { expect } = require('chai')
+const { describe, it, before } = require('mocha')
+const React = require('react')
+const ReactDOMServer = require('react-dom/server')
+
+describe('smoke -- public surface boots', () => {
+  const LIB_DIR = path.join(__dirname, '..', 'lib')
+  const LIB_INDEX = path.join(LIB_DIR, 'index.js')
+
+  it('build artifact exists', () => {
+    if (!fs.existsSync(LIB_DIR)) {
+      throw new Error('lib/ does not exist; run `yarn build` first.')
+    }
+    if (!fs.existsSync(LIB_INDEX)) {
+      throw new Error('lib/index.js does not exist; build did not produce expected entry.')
+    }
+  })
+
+  describe('public exports', () => {
+    let lib
+
+    before(() => {
+      // Load via the package's `main` field rather than via src/, so the
+      // smoke exercises what npm consumers actually import.
+      lib = require('../lib')
+    })
+
+    it('exports MalibuIcon as a function', () => {
+      expect(lib.MalibuIcon).to.be.a('function')
+    })
+
+    it('exports MalibuSprites as a function', () => {
+      expect(lib.MalibuSprites).to.be.a('function')
+    })
+  })
+
+  describe('server-render', () => {
+    let lib
+
+    before(() => {
+      lib = require('../lib')
+    })
+
+    it('MalibuSprites renders to non-empty HTML', () => {
+      const html = ReactDOMServer.renderToStaticMarkup(
+        React.createElement(lib.MalibuSprites)
+      )
+      expect(html).to.be.a('string')
+      expect(html.length).to.be.greaterThan(0)
+    })
+
+    it('MalibuIcon renders an <svg> tag for a known icon', () => {
+      const html = ReactDOMServer.renderToStaticMarkup(
+        React.createElement(lib.MalibuIcon, { name: 'add-badge-16' })
+      )
+      expect(html).to.be.a('string')
+      expect(html).to.include('<svg')
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds `tests/smoke_test.js` -- 5 assertions verifying the published
`@heroku/react-malibu` surface boots correctly. Picked up automatically
by the existing `mocha tests/*_test.js` glob; no script changes required.

## Why

Establishes layer **L4 (smoke)** of the workspace verification ladder
defined in [`heroku/3pp-grackle/docs/verification-specs/react-malibu.md`](https://github.com/heroku/3pp-grackle/blob/main/docs/verification-specs/react-malibu.md).

The ladder makes future dependency-upgrade PRs (babysit-generated or
otherwise) verifiable with high confidence: lint + build + unit + smoke
all pass before merge.

This is the **Phase 1 pilot** for the Node-library pattern -- the same
shape will be reused for `@heroku/react-hk-components`, `@heroku/torii-provider-heroku`,
and the ember libraries.

## Asserts

1. ``yarn build`` produces ``lib/index.js``
2. ``require('../lib').MalibuIcon`` is a function
3. ``require('../lib').MalibuSprites`` is a function
4. ``ReactDOMServer.renderToStaticMarkup(<MalibuSprites />)`` produces non-empty HTML
5. ``ReactDOMServer.renderToStaticMarkup(<MalibuIcon name='add-badge-16' />)`` includes ``<svg``

## Local verification

```
$ yarn test
✔ MalibuIcon (7 tests)
✔ MalibuSprite (3 tests)
✔ smoke -- public surface boots (5 tests)
15 passing (39ms)
```

## Behavior change

**None.** This PR only adds a test file and a `.gitignore` entry for
`.logs/` (used by the verification-spec process to keep run logs out
of the repo). No source code touched.

## Recommended follow-up: CI workflow

The legacy `.travis.yml` only fires on `master` (this repo no longer
uses that branch), so the current effective CI signal is zero. A
GitHub Actions workflow that runs lint + build + test on every PR
would close that gap. Suggested content (deferred from this PR per
local security-hook policy on workflow edits):

```
name: CI
on:
  pull_request:
  push:
    branches: [main]
jobs:
  ci:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with: { node-version: 20.19.4, cache: yarn }
      - run: yarn install --frozen-lockfile
      - run: yarn run lint
      - run: yarn build
      - run: yarn run mocha --require jsdom-global/register --require @babel/register 'tests/*_test.js'
```

## Refs

- 3pp-grackle Phase 1 verification-specs initiative
- Spec: [`docs/verification-specs/react-malibu.md`](https://github.com/heroku/3pp-grackle/blob/main/docs/verification-specs/react-malibu.md)
- Cross-repo index: [`docs/verification-specs/INDEX.md`](https://github.com/heroku/3pp-grackle/blob/main/docs/verification-specs/INDEX.md)