### PR TITLE
security: override tmp to fix insecure temporary file creation (GHSA-ph9p-34f9-6g65)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-react/**/minimatch": "^3.1.4",
     "mocha/**/minimatch": "^9.0.7",
     "np/**/minimatch": "^9.0.7",
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": ">=7.0.3",
+    "tmp": "^0.2.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4947,11 +4947,6 @@ org-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/org-regex/-/org-regex-1.0.0.tgz#67ebb9ab3cb124fea5841289d60b59434f041a59"
   integrity sha512-7bqkxkEJwzJQUAlyYniqEZ3Ilzjh0yoa62c7gL6Ijxj5bEpPL+8IE1Z0PFj0ywjjXQcdrwR51g9MIcLezR0hKQ==
 
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
-
 own-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.1.tgz#e4006910a2bf913585289676eebd6f390cf51358"
@@ -6101,12 +6096,10 @@ tldts@^6.1.32:
   dependencies:
     tldts-core "^6.1.86"
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tmp@^0.0.33, tmp@^0.2.6:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/f9f4ec17-d8db-42f8-bf58-dcda12a12663" width="24" align="top"> **3PP Grackle** (automated dependency triage -- Frontend DX) -- **babysit** _(AT run `84db7c2c`)_

## Summary

Fixes 1 **high** severity 3PP vulnerability in `tmp` (GHSA-ph9p-34f9-6g65).

`tmp` prior to 0.2.6 creates temporary files with predictable names and insecure default permissions, allowing local attackers to read or modify sensitive temporary data.

**Production risk:** Build-time only: `tmp` only appears under `external-editor` -> `inquirer` -> `np`, which is a devDependency. It is not loaded by the production runtime.

**Strategy:** override (yarn resolution)

## Why

`tmp@0.0.33` has an insecure temporary file creation vulnerability (GHSA-ph9p-34f9-6g65, HIGH), first patched in 0.2.6. The package is pulled in transitively by `external-editor@3.1.0` (the latest release), which declares `tmp@^0.0.33` -- a range that will never resolve to 0.2.x. Since `external-editor` has no newer release that updates this range, a yarn resolution is the only available fix without replacing the entire `inquirer` -> `external-editor` chain.

## Changes

### package.json

Added a yarn `resolutions` entry to force `tmp` to `^0.2.6`:

```json
"tmp": "^0.2.6"
```

**Why resolution override?** `external-editor@3.1.0` (latest) declares `tmp@^0.0.33`, a range that cannot resolve to 0.2.x. There is no newer release of `external-editor` that bumps this range. The resolution forces yarn to resolve `tmp` to 0.2.7 (latest in the 0.2.x line) across the entire tree.

### yarn.lock

Lockfile re-resolved: `tmp` moved from 0.0.33 to 0.2.7. The `os-tmpdir` transitive dependency (only needed by tmp@0.0.x) is removed from the tree.

## Resolutions and overrides

| Override Key | Version | Why Override? | When to Remove | Reference |
|---|---|---|---|---|
| `tmp` | `^0.2.6` | Transitive via `external-editor@3.1.0` (used by `inquirer`, a dep of `np`). `external-editor` declares `tmp@^0.0.33` which cannot resolve to 0.2.x; no newer release exists. Resolution forces safe version. | Remove when `external-editor` releases a version whose range declares `tmp@>=0.2.6`. Track upstream: https://github.com/mrkmg/node-external-editor/releases. Verify with `3pp-util trace-vuln tmp`. Reviewer-local: `yarn why tmp`. | [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) |

## Risk Classification

This vulnerability exists only in build-tool dependencies. Production risk: NONE. Remediation prevents scanner noise and supply-chain exposure during CI.

## Vulnerabilities Fixed

| CVE/GHSA | Package | Severity | Fixed Version |
|----------|---------|----------|---------------|
| GHSA-ph9p-34f9-6g65 | tmp | high | ^0.2.6 |

## How to test

```bash
# Install with the patched version hoisted
yarn install

# Verify tmp resolved to >= 0.2.6
yarn why tmp
# expect: tmp@0.2.7

# Project-wide gates
yarn run lint
yarn run build
yarn run test
```

## Validation

Validation is a before/after comparison. The baseline captured pre-existing install failures due to the corepack ancestor-walk issue (unrelated to this fix).

- Install (baseline / post-fix): FAIL (corepack) / PASS
- Tests (baseline / post-fix): FAIL (blocked by install) / PASS
- Lint (baseline / post-fix): FAIL (blocked by install) / PASS
- Build (baseline / post-fix): FAIL (blocked by install) / PASS

All four phases recovered after the fix was applied. No regressions introduced.

## Notes

- Dependency chain: `np` (devDep) -> `inquirer` -> `external-editor` -> `tmp@^0.0.33`
- `tmp@0.2.x` drops the `os-tmpdir` dependency entirely (uses Node built-in `os.tmpdir()`)
- `external-editor` is at its latest release (3.1.0, published 2019) and is unlikely to receive updates

---
<sub>skill-sig: `26cfcbaf` · grackle-sig: `84db7c2c` · 3pp-skill-sig: `ad61853a` · 3pp-skill canonical pipeline · 3pp-grackle babysit</sub>

<!-- 3pp-grackle-babysit:v1 run_id=babysit-2026-06-15-22-29-49 short_id=84db7c2c -->
